### PR TITLE
データ管理方法の追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -120,7 +120,7 @@ Style/GuardClause:
   Enabled: true
 
 Metrics/ParameterLists:
-  Max: 3
+  Max: 4
   CountKeywordArgs: true
 
 Security/Eval:

--- a/lib/hatenablog_publisher.rb
+++ b/lib/hatenablog_publisher.rb
@@ -9,6 +9,7 @@ require 'hatenablog_publisher/api'
 require 'hatenablog_publisher/generator/body'
 require 'hatenablog_publisher/request_logger'
 require 'hatenablog_publisher/fixed_content/ad'
+require 'hatenablog_publisher/io'
 
 module HatenablogPublisher
   class Error < StandardError; end

--- a/lib/hatenablog_publisher/client.rb
+++ b/lib/hatenablog_publisher/client.rb
@@ -7,8 +7,9 @@ module HatenablogPublisher
     attr_reader :context
 
     def initialize(args)
-      @context = HatenablogPublisher::Context.new(args[:filename])
       @options = HatenablogPublisher::Options.new(args)
+      io = HatenablogPublisher::Io.new(@options)
+      @context = HatenablogPublisher::Context.new(io)
     end
 
     def publish

--- a/lib/hatenablog_publisher/client.rb
+++ b/lib/hatenablog_publisher/client.rb
@@ -15,11 +15,12 @@ module HatenablogPublisher
     def publish
       image_tags = @context.text.scan(/[^`]!\[.*\]\((.*)\)/).flatten
       photolife = HatenablogPublisher::Photolife.new
+      dirname = File.dirname(@options.args[:filename])
 
       image_tags.each do |tag|
         next if @context.posted_image?(tag)
 
-        image = HatenablogPublisher::Image.new(File.join(@context.dirname, tag))
+        image = HatenablogPublisher::Image.new(File.join(dirname, tag))
         image_hash = photolife.upload(image)
         @context.add_image_context(image_hash, tag)
         @context.reload_context

--- a/lib/hatenablog_publisher/context.rb
+++ b/lib/hatenablog_publisher/context.rb
@@ -4,12 +4,10 @@ require 'active_support/core_ext/hash'
 
 module HatenablogPublisher
   class Context
-    attr_reader :filename, :title, :categories, :text, :hatena, :dirname, :basename
+    attr_reader :title, :categories, :text, :hatena
 
-    def initialize(filename)
-      @filename = filename
-      @dirname = File.dirname(filename)
-      @basename = File.basename(filename)
+    def initialize(io)
+      @io = io
 
       read_context
     end
@@ -46,30 +44,17 @@ module HatenablogPublisher
 
     private
 
-    def front_matter
-      {
-        title: @title,
-        category: @categories,
-        hatena: @hatena
-      }.deep_stringify_keys
-    end
-
     def write_context
-      body = YAML.dump(front_matter) + "\n---\n\n" + @text
-      File.write(@filename, body)
+      @io.write(title: @title, category: @categories, hatena: @hatena, text: @text)
     end
 
     def read_context
-      parsed = FrontMatterParser::Parser.parse_file(@filename)
+      data, text = @io.read
 
-      @title = parsed.front_matter['title']
-      @categories = parsed.front_matter['category']
-      @text = parsed.content
-      @hatena = if parsed.front_matter['hatena'].nil?
-                  {}
-                else
-                  parsed.front_matter['hatena'].deep_symbolize_keys
-                end
+      @text = text
+      @categories = data[:category]
+      @title = data[:title]
+      @hatena = data[:hatena] || {}
     end
   end
 end

--- a/lib/hatenablog_publisher/entry.rb
+++ b/lib/hatenablog_publisher/entry.rb
@@ -17,8 +17,9 @@ module HatenablogPublisher
 
     def post_entry(body)
       request_xml = format_request(body)
+      basename = File.basename(@options.args[:filename])
 
-      res = with_logging_request(@context.basename, request_xml) do
+      res = with_logging_request(basename, request_xml) do
         method = @context.hatena.dig(:id) ? :put : :post
         @client.request(api_url, request_xml, method)
       end

--- a/lib/hatenablog_publisher/io.rb
+++ b/lib/hatenablog_publisher/io.rb
@@ -1,0 +1,63 @@
+module HatenablogPublisher
+  class Io
+    def initialize(options)
+      @options = options
+    end
+
+    def data_file?
+      data_file.present?
+    end
+
+    def data_file
+      @options.args[:data_file]
+    end
+
+    def write(title:, category:, hatena:, text:)
+      if data_file?
+        write_data_file(title: title, category: category, hatena: hatena)
+      else
+        write_file(title: title, category: category, hatena: hatena, text: text)
+      end
+    end
+
+    def write_data_file(title:, category:, hatena:)
+      data = JSON.parse(File.read(@options.args[:data_file]))
+      data.each do |l|
+        next if l['filepath'] == @options.args[:filename]
+
+        l.merge!(
+          title: title,
+          category: category,
+          hatena: hatena
+        )
+      end
+      File.write(JSON.dump(data), data_file)
+    end
+
+    def write_file(title:, category:, hatena:, text:)
+      parsed = FrontMatterParser::Parser.parse_file(filename)
+      front_matter = parsed.front_matter.deep_symbolize_keys.merge(
+        title: title,
+        category: category,
+        hatena: hatena
+      )
+      body = YAML.dump(front_matter) + "\n---\n\n" + text
+      File.write(@filename, body)
+    end
+
+    def read
+      filename = @options.args[:filename]
+
+      if data_file?
+        json = JSON.parse(File.read(data_file))
+        target = json.find { |l| l['filepath'] == filename }
+
+        [target.deep_symbolize_keys, File.read(filename)]
+      else
+        parsed = FrontMatterParser::Parser.parse_file(filename)
+
+        [parsed.front_matter.deep_symbolize_keys, parsed.content]
+      end
+    end
+  end
+end

--- a/lib/hatenablog_publisher/io.rb
+++ b/lib/hatenablog_publisher/io.rb
@@ -35,14 +35,15 @@ module HatenablogPublisher
     end
 
     def write_file(title:, category:, hatena:, text:)
+      filename = @options.args[:filename]
       parsed = FrontMatterParser::Parser.parse_file(filename)
       front_matter = parsed.front_matter.deep_symbolize_keys.merge(
         title: title,
         category: category,
         hatena: hatena
       )
-      body = YAML.dump(front_matter) + "\n---\n\n" + text
-      File.write(@filename, body)
+      body = YAML.dump(front_matter.deep_stringify_keys) + "\n---\n\n" + text
+      File.write(filename, body)
     end
 
     def read

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe HatenablogPublisher::Context do
 
   describe '.read_context' do
     context '初回投稿時の状態の.md' do
-      let(:context) { described_class.new('./spec/support/sample.md') }
+      let(:context) do
+        options = HatenablogPublisher::Options.new(filename: './spec/support/sample.md')
+        io = HatenablogPublisher::Io.new(options)
+        described_class.new(io)
+      end
       subject {context}
 
       it 'title,categoryが読めているか' do
@@ -23,7 +27,11 @@ RSpec.describe HatenablogPublisher::Context do
     end
 
     context '更新投稿時の.md' do
-      subject { described_class.new('./spec/support/sample2.md') }
+      subject do
+        options = HatenablogPublisher::Options.new(filename: './spec/support/sample2.md')
+        io = HatenablogPublisher::Io.new(options)
+        described_class.new(io)
+      end
       let(:hatena) do {
         image: {
           'sample01.png': image1_context,
@@ -45,7 +53,11 @@ RSpec.describe HatenablogPublisher::Context do
     let(:photolife_api) {HatenablogPublisher::Photolife.new}
     let(:image1) {HatenablogPublisher::Image.new('spec/support/sample01.png')}
     let(:image2) {HatenablogPublisher::Image.new('spec/support/sample02.png')}
-    let(:context) {described_class.new('spec/support/sample.md')}
+    let(:context) do
+      options = HatenablogPublisher::Options.new(filename: './spec/support/sample.md')
+      io = HatenablogPublisher::Io.new(options)
+      described_class.new(io)
+    end
 
     before do
       allow(photolife_api.client.client).to receive(:request).and_return(xml1, xml2)
@@ -81,7 +93,9 @@ RSpec.describe HatenablogPublisher::Context do
 
   describe '.add_entry_context' do
     let(:xml) { OpenStruct.new(body: File.read('spec/support/entry-sample.md-response.xml')) }
-    let(:options) { HatenablogPublisher::Options.new({}) }
+    let(:options) { HatenablogPublisher::Options.new(filename: './spec/support/sample.md') }
+    let(:io) { HatenablogPublisher::Io.new(options) }
+    let(:context) { described_class.new(io) }
     let(:entry_api) { HatenablogPublisher::Entry.new(context, options) }
 
     before do
@@ -89,7 +103,6 @@ RSpec.describe HatenablogPublisher::Context do
     end
 
     context '初回投稿時' do
-      let(:context) { described_class.new('spec/support/sample.md') }
       let(:entry_hash) {entry_api.post_entry('dummy text')}
 
       it 'entry_idが追加されているか' do
@@ -101,7 +114,7 @@ RSpec.describe HatenablogPublisher::Context do
     end
 
     context '更新投稿時' do
-      let(:context) { described_class.new('spec/support/sample2.md') }
+      let(:options) { HatenablogPublisher::Options.new(filename: './spec/support/sample2.md') }
       let(:entry_hash) {entry_api.post_entry('dummy text')}
       let!(:before_hatena) {context.hatena}
 


### PR DESCRIPTION
投稿済みかどうかを判断するためmarkdownファイルとentryのID

画像とfotolifeのIDをデータとして持つ



- markdownファイルのfront_matterにIDなどを保存
- new! 1ファイル(json)に全ての記事データを用意し随時更新していく