### PR TITLE
feat: textlintでの除外コメントを投稿時には削除する

### DIFF
--- a/lib/hatenablog_publisher/generator/body.rb
+++ b/lib/hatenablog_publisher/generator/body.rb
@@ -13,9 +13,13 @@ module HatenablogPublisher
       def generate
         markdown = @context.text.dup
 
-        replaced_markdown = replace_image(markdown)
+        replaced_markdown = remove_textlint_comment(replace_image(markdown))
 
         CGI.escapeHTML(replaced_markdown)
+      end
+
+      def remove_textlint_comment(markdown)
+        markdown.gsub(/^<!--\s+textlint-(enable|disable).*-->\n/, '')
       end
 
       def replace_image(markdown)

--- a/spec/generator/body_spec.rb
+++ b/spec/generator/body_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HatenablogPublisher::Generator::Body do
       HatenablogPublisher::Context.new(io)
     end
 
-    subject { HatenablogPublisher::Generator::Body.new(context, options).replace_image(context.text) }
+    subject { HatenablogPublisher::Generator::Body.new(context, options).generate }
 
     context '直リンクの画像が含まれる時' do
       it 'そのまま出力されているか' do
@@ -18,6 +18,17 @@ RSpec.describe HatenablogPublisher::Generator::Body do
       it 'はてな記法に変換されているか' do
         is_expected.to include('[f:id:hoge:11111111111111p:image]')
         is_expected.to include('[f:id:hoge:22222222222222p:image]')
+      end
+    end
+
+    context 'textlintの除外コメントが含まれる時' do
+      it '削除されているか' do
+        is_expected.to_not include('<!-- textlint-enable')
+        is_expected.to_not include('<!-- textlint-disable')
+      end
+
+      it 'コメントで囲った箇所は残っているか' do
+        is_expected.to include('だと思います')
       end
     end
   end

--- a/spec/support/sample2.md
+++ b/spec/support/sample2.md
@@ -48,4 +48,8 @@ type Props = HogeProps & PartialP2
 
 ## title4
 
+<!-- textlint-disable ja-technical-writing/ja-no-weak-phrase -->
+まるだと思います
+<!-- textlint-enable ja-technical-writing/ja-no-weak-phrase -->
 
+おわり


### PR DESCRIPTION
- API経由で投稿可能な文字数に制限があるようなのではてなブログ投稿時に無駄になる文字列を削除する