### PR TITLE
fix: フォトライフのイメタグのタイプを変更

### DIFF
--- a/lib/hatenablog_publisher/context.rb
+++ b/lib/hatenablog_publisher/context.rb
@@ -19,7 +19,8 @@ module HatenablogPublisher
     end
 
     def add_image_context(image, tag)
-      syntax = "[#{image['syntax'].first}]"
+      # APIのレスポンスをそのまま使用すると記事上でフォトライフへのリンクになってしまうため、管理画面から画像投稿した結果と合わせた(image -> plain)
+      syntax = "[#{image['syntax'].first}]".gsub(/:image\]/,':plain]')
 
       @hatena ||= {}
       @hatena[:image] ||= {}

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -3,8 +3,8 @@ require 'oauth'
 require 'awesome_print'
 
 RSpec.describe HatenablogPublisher::Context do
-  let(:image1_context) { {syntax: '[f:id:hoge:11111111111111p:image]', id: 'tag:hatena.ne.jp,2005:fotolife-hoge-11111111111111', image_url: 'https://cdn-ak.f.st-hatena.com/images/fotolife/s/hoge/20200509/20200509150000.png'} }
-  let(:image2_context) { {syntax:  '[f:id:hoge:22222222222222p:image]', id: 'tag:hatena.ne.jp,2005:fotolife-hoge-22222222222222', image_url: 'https://cdn-ak.f.st-hatena.com/images/fotolife/s/hoge/20200509/20200509150001.png'} }
+  let(:image1_context) { {syntax: '[f:id:hoge:11111111111111p:plain]', id: 'tag:hatena.ne.jp,2005:fotolife-hoge-11111111111111', image_url: 'https://cdn-ak.f.st-hatena.com/images/fotolife/s/hoge/20200509/20200509150000.png'} }
+  let(:image2_context) { {syntax:  '[f:id:hoge:22222222222222p:plain]', id: 'tag:hatena.ne.jp,2005:fotolife-hoge-22222222222222', image_url: 'https://cdn-ak.f.st-hatena.com/images/fotolife/s/hoge/20200509/20200509150001.png'} }
   let(:categories) { ['Markdown', 'Sample'] }
   let(:title) { 'サンプルマークダウン' }
   let(:updated) { '2020-05-10T18:30:30' } # sample2.mdと同様

--- a/spec/generator/body_spec.rb
+++ b/spec/generator/body_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe HatenablogPublisher::Generator::Body do
 
     context '画像が含まれる時' do
       it 'はてな記法に変換されているか' do
-        is_expected.to include('[f:id:hoge:11111111111111p:image]')
-        is_expected.to include('[f:id:hoge:22222222222222p:image]')
+        is_expected.to include('[f:id:hoge:11111111111111p:plain]')
+        is_expected.to include('[f:id:hoge:22222222222222p:plain]')
       end
     end
 

--- a/spec/support/sample2.md
+++ b/spec/support/sample2.md
@@ -7,11 +7,11 @@ updated: '2020-05-10T18:30:30'
 hatena:
   image:
     sample01.png:
-      syntax: "[f:id:hoge:11111111111111p:image]"
+      syntax: "[f:id:hoge:11111111111111p:plain]"
       id: tag:hatena.ne.jp,2005:fotolife-hoge-11111111111111
       image_url: https://cdn-ak.f.st-hatena.com/images/fotolife/s/hoge/20200509/20200509150000.png
     sample02.png:
-      syntax: "[f:id:hoge:22222222222222p:image]"
+      syntax: "[f:id:hoge:22222222222222p:plain]"
       id: tag:hatena.ne.jp,2005:fotolife-hoge-22222222222222
       image_url: https://cdn-ak.f.st-hatena.com/images/fotolife/s/hoge/20200509/20200509150001.png
   id: '11111111111111111'


### PR DESCRIPTION
APIのレスポンスをそのまま使うと次のようなタグが返ってくる

`[f:id:swfz:20201212235741p:image]`

しかしこのまま投稿するとリンク先がフォトライフになってしまう

GUIでの画像アップロード時は次のように末尾に`plain`とついている状態なのでその状態に合わせた

`[f:id:swfz:20201212235741p:plain]`
