### PR TITLE
fix(ci): slack-workflow-statusをnode24対応フォークに切り替え

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     name: post slack
     runs-on: ubuntu-latest
     steps:
-      - uses: Gamesight/slack-workflow-status@v1.3.0
+      - uses: swfz/slack-workflow-status@v1.4.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- `Gamesight/slack-workflow-status` or `swfz/slack-workflow-status@feature/*` → `swfz/slack-workflow-status@v1.4.0` に変更
- Node.js 20 deprecation対応（2026年6月2日からNode.js 24が強制デフォルト）
- フォーク側で `action.yml` の `using: node20` → `node24` に更新済み

## Test plan
- [ ] CIが正常に動作すること
- [ ] Slack通知が届くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)