### PR TITLE
fix(ci): RuboCopとactions/cacheのdeprecation対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s
+          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b ./bin
           rubocop | ./bin/reviewdog -f=rubocop -reporter=github-pr-review
 
   slack-notify:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v5.0.5
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('./Gemfile.lock') }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ Lint/AmbiguousBlockAssociation:
 Metrics/ClassLength:
   Max: 100
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/MethodLength:
@@ -72,8 +72,8 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInArguments:
   Enabled: true
 
-Naming/PredicateName:
-  NamePrefix:
+Naming/PredicatePrefix:
+  ForbiddenPrefixes:
     - has_
     - have_
 

--- a/lib/hatenablog_publisher/context.rb
+++ b/lib/hatenablog_publisher/context.rb
@@ -21,7 +21,7 @@ module HatenablogPublisher
 
     def add_image_context(image, tag)
       # APIのレスポンスをそのまま使用すると記事上でフォトライフへのリンクになってしまうため、管理画面から画像投稿した結果と合わせた(image -> plain)
-      syntax = "[#{image['syntax'].first}]".gsub(/:image\]/,':plain]')
+      syntax = "[#{image['syntax'].first}]".gsub(/:image\]/, ':plain]')
 
       @hatena ||= {}
       @hatena[:image] ||= {}

--- a/lib/hatenablog_publisher/entry.rb
+++ b/lib/hatenablog_publisher/entry.rb
@@ -20,7 +20,7 @@ module HatenablogPublisher
       basename = File.basename(@options.filename)
 
       res = with_logging_request(basename, request_xml) do
-        method = @context.hatena.dig(:id) ? :put : :post
+        method = @context.hatena[:id] ? :put : :post
         @client.request(api_url, request_xml, method)
       end
 
@@ -30,7 +30,7 @@ module HatenablogPublisher
     private
 
     def api_url
-      id = @context.hatena.dig(:id) ? '/' + @context.hatena[:id] : ''
+      id = @context.hatena[:id] ? "/#{@context.hatena[:id]}" : ''
       "#{ENDPOINT}/#{@options.user}/#{@options.site}/atom/entry#{id}"
     end
 
@@ -42,7 +42,7 @@ module HatenablogPublisher
       return unless @context.categories
 
       @context.categories.map do |c|
-        '<category term="' + c + '" />'
+        "<category term=\"#{c}\" />"
       end.join
     end
 
@@ -56,7 +56,7 @@ module HatenablogPublisher
 
     def format_request(body)
       draft = @options.draft ? 'yes' : 'no'
-      body = <<~"XML"
+      <<~"XML"
         <?xml version="1.0" encoding="utf-8"?>
           <entry xmlns="http://www.w3.org/2005/Atom"
         xmlns:app="http://www.w3.org/2007/app">
@@ -73,7 +73,6 @@ module HatenablogPublisher
           #{custom_path}
         </entry>
       XML
-      body
     end
   end
 end

--- a/lib/hatenablog_publisher/fixed_content/ad.rb
+++ b/lib/hatenablog_publisher/fixed_content/ad.rb
@@ -10,7 +10,7 @@ module HatenablogPublisher
       end
 
       def format_body
-        "\n\n\n" + CGI.escapeHTML(sample_items.join("\n"))
+        "\n\n\n#{CGI.escapeHTML(sample_items.join("\n"))}"
       end
 
       def sample_items

--- a/lib/hatenablog_publisher/generator/body.rb
+++ b/lib/hatenablog_publisher/generator/body.rb
@@ -29,7 +29,7 @@ module HatenablogPublisher
           if image_name.match('^http')
             s
           else
-            "\n\n" + @context.image_syntax(image_name)
+            "\n\n#{@context.image_syntax(image_name)}"
           end
         end
       end

--- a/lib/hatenablog_publisher/io.rb
+++ b/lib/hatenablog_publisher/io.rb
@@ -38,7 +38,7 @@ module HatenablogPublisher
       filename = @options.filename
       parsed = FrontMatterParser::Parser.parse_file(filename, loader: yaml_loader)
       front_matter = parsed.front_matter.deep_symbolize_keys.merge(metadata)
-      body = YAML.dump(front_matter.deep_stringify_keys) + "\n---\n\n" + text
+      body = "#{YAML.dump(front_matter.deep_stringify_keys)}\n---\n\n#{text}"
       File.write(filename, body)
     end
 

--- a/lib/hatenablog_publisher/photolife.rb
+++ b/lib/hatenablog_publisher/photolife.rb
@@ -29,7 +29,7 @@ module HatenablogPublisher
     end
 
     def format_body(image, dirname = 'Hatena Blog')
-      body = <<~"XML"
+      <<~"XML"
         <entry xmlns="http://purl.org/atom/ns#">
           <title>#{image.title}</title>
           <content mode="base64" type="#{image.mime_type}">
@@ -38,8 +38,6 @@ module HatenablogPublisher
           <dc:subject>#{dirname}</dc:subject>
         </entry>
       XML
-
-      body
     end
   end
 end


### PR DESCRIPTION
## Summary
- `actions/cache@v4.0.2`がdeprecated強制失敗するためv5.0.5へ更新
- RuboCop obsolete cop対応: `Metrics/LineLength` → `Layout/LineLength`, `Naming/PredicateName` → `Naming/PredicatePrefix`
- RuboCop 1.86系で新規検出されたoffenseをautocorrectで修正(意味論等価な変換のみ)

## Test plan
- [ ] CI (test matrix 2.6-3.2)が通ること
- [ ] CI (rubocop)が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)